### PR TITLE
Detatch histogram from render widget

### DIFF
--- a/VolumeApp.pro
+++ b/VolumeApp.pro
@@ -14,6 +14,7 @@ SOURCES += \
     crosssectionrenderer.cpp \
     environment.cpp \
     geometry.cpp \
+    histogramwidget.cpp \
     main.cpp \
     mainwindow.cpp \
     node.cpp \
@@ -27,6 +28,7 @@ HEADERS += \
     crosssectionrenderer.h \
     environment.h \
     geometry.h \
+    histogramwidget.h \
     mainwindow.h \
     node.h \
     renderwidget.h \

--- a/VolumeApp.pro
+++ b/VolumeApp.pro
@@ -19,6 +19,8 @@ SOURCES += \
     mainwindow.cpp \
     node.cpp \
     renderwidget.cpp \
+    sidebar.cpp \
+    transferfunctionbuttonbar.cpp \
     transferfunctionrenderer.cpp \
     transferfunctiontexturegenerator.cpp \
     transferfunctionwidget.cpp \
@@ -32,6 +34,8 @@ HEADERS += \
     mainwindow.h \
     node.h \
     renderwidget.h \
+    sidebar.h \
+    transferfunctionbuttonbar.h \
     transferfunctionrenderer.h \
     transferfunctiontexturegenerator.h \
     transferfunctionwidget.h \

--- a/histogram-fs.glsl
+++ b/histogram-fs.glsl
@@ -10,11 +10,13 @@ void main(void)
 //    uint value = imageLoad(histogramImage,ivec2(gl_FragCoord.xy)).r;
 //    float scaled = clamp(log(value)/8.0,0.0,1.0);
 //    fragmentColor = vec4(scaled,scaled,scaled,1.0);
+
     uint value = imageLoad(histogramImage,ivec2(gl_FragCoord.x)).r;
     float scaled = clamp(log(value)/8.0,0.0,1.0);
     float green = 1;
     if (scaled<=texturePosition.y){
         fragmentColor = vec4(1);
+
     }
     else {
         fragmentColor = vec4(texturePosition.x,texturePosition.y, 0,1);

--- a/histogramwidget.cpp
+++ b/histogramwidget.cpp
@@ -1,0 +1,106 @@
+#include "histogramwidget.h"
+
+HistogramWidget::HistogramWidget(Environment *env, QWidget *parent)
+    : QOpenGLWidget{parent},
+      m_environment(env),
+      m_volumeTexture(QOpenGLTexture::Target3D),
+      m_histogramTexture(QOpenGLTexture::Target2D)
+{
+}
+
+
+void HistogramWidget::initializeGL(){
+    initializeOpenGLFunctions();
+
+    // initialize geometry
+    Geometry::instance();
+
+    //Histogram
+    if (!m_histogramProgram.addShaderFromSourceFile(QOpenGLShader::Vertex,":/shaders/histogram-vs.glsl"))
+        qDebug() << "Could not load vertex shader!";
+
+    if (!m_histogramProgram.addShaderFromSourceFile(QOpenGLShader::Fragment,":/shaders/histogram-fs.glsl"))
+        qDebug() << "Could not load fragment shader!";
+
+    if (!m_histogramProgram.link())
+        qDebug() << "Could not link shader program!";
+    //Compute
+    if (!m_computeProgram.addShaderFromSourceFile(QOpenGLShader::Compute,":/shaders/volume-cs.glsl"))
+        qDebug() << "Could not load compute shader!";
+
+    if (!m_computeProgram.link())
+        qDebug() << "Could not link shader program!";
+
+    m_histogramTexture.setBorderColor(0,0,0,0);
+    m_histogramTexture.setWrapMode(QOpenGLTexture::ClampToEdge);
+    m_histogramTexture.setFormat(QOpenGLTexture::R32U);
+    m_histogramTexture.setMinificationFilter(QOpenGLTexture::Linear);
+    m_histogramTexture.setMagnificationFilter(QOpenGLTexture::Linear);
+    m_histogramTexture.setAutoMipMapGenerationEnabled(false);
+    m_histogramTexture.setSize(256,256);
+    m_histogramTexture.allocateStorage();
+}
+
+
+void HistogramWidget::resizeGL(int w, int h){
+
+}
+
+
+void HistogramWidget::paintGL(){
+    glClearColor(1.0f,1.0f,1.0f,1.0f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    //BRUH
+    glEnable(GL_DEPTH_TEST);
+    glDepthFunc(GL_LESS);
+
+    m_histogramProgram.bind();
+    Geometry::instance()->bindQuad();
+
+    glBindImageTexture(0,m_histogramTexture.textureId(),0,GL_FALSE,0,GL_READ_ONLY,GL_R32UI);
+
+    int location = m_histogramProgram.attributeLocation("vertexPosition");
+    m_histogramProgram.enableAttributeArray(location);
+    m_histogramProgram.setAttributeBuffer(location,GL_FLOAT,0,3,sizeof(QVector3D));
+
+    Geometry::instance()->drawQuad();
+    m_histogramProgram.release();
+
+    m_histogramTexture.release();
+}
+
+
+void HistogramWidget::doCompute(){
+    if (m_volumeTexture.width() != m_environment->volume()->width() || m_volumeTexture.height() != m_environment->volume()->height() || m_volumeTexture.depth() != m_environment->volume()->depth())
+    {
+        if (m_volumeTexture.isCreated())
+            m_volumeTexture.destroy();
+
+        m_volumeTexture.setBorderColor(0,0,0,0);
+        m_volumeTexture.setWrapMode(QOpenGLTexture::ClampToBorder);
+        m_volumeTexture.setFormat(QOpenGLTexture::R32F);
+        m_volumeTexture.setMinificationFilter(QOpenGLTexture::Linear);
+        m_volumeTexture.setMagnificationFilter(QOpenGLTexture::Linear);
+        m_volumeTexture.setAutoMipMapGenerationEnabled(false);
+        m_volumeTexture.setSize(m_environment->volume()->width(),m_environment->volume()->height(),m_environment->volume()->depth());
+        m_volumeTexture.allocateStorage();
+    }
+
+
+    int groupSizeX = 4, groupSizeY = 4, groupSizeZ = 4;
+    int numGroupsX = ceilf(float(m_environment->volume()->width())/float(groupSizeX));
+    int numGroupsY = ceilf(float(m_environment->volume()->height())/float(groupSizeY));
+    int numGroupsZ = ceilf(float(m_environment->volume()->depth())/float(groupSizeZ));
+
+    m_computeProgram.bind();
+    m_environment->volume()->bind();
+    glBindImageTexture(0,m_environment->volume()->volumeTexture().textureId(),0,GL_TRUE,0,GL_READ_ONLY,GL_R32F);
+    glBindImageTexture(1,m_volumeTexture.textureId(),0,GL_TRUE,0,GL_WRITE_ONLY,GL_R32F);
+    glBindImageTexture(2,m_histogramTexture.textureId(),0,GL_FALSE,0,GL_READ_WRITE,GL_R32UI);
+    glDispatchCompute(numGroupsX,numGroupsY,numGroupsZ);
+    m_environment->volume()->release();
+    m_computeProgram.release();
+
+    update();
+}

--- a/histogramwidget.h
+++ b/histogramwidget.h
@@ -1,0 +1,35 @@
+#ifndef HISTOGRAMWIDGET_H
+#define HISTOGRAMWIDGET_H
+
+#include <QWidget>
+#include <QOpenGLWidget>
+#include <QOpenGLShaderProgram>
+#include <QOpenGLExtraFunctions>
+#include "environment.h"
+#include "geometry.h"
+
+class HistogramWidget : public QOpenGLWidget, protected QOpenGLExtraFunctions
+{
+    Q_OBJECT
+public:
+    explicit HistogramWidget(Environment *env, QWidget *parent = nullptr);
+public slots:
+    void doCompute();
+
+
+signals:
+protected:
+    virtual void initializeGL();
+    virtual void resizeGL(int w, int h);
+    virtual void paintGL();
+
+private:
+    Environment *m_environment;
+    QOpenGLTexture m_volumeTexture;
+    QOpenGLTexture m_histogramTexture;
+    QOpenGLShaderProgram m_histogramProgram;
+    QOpenGLShaderProgram m_computeProgram;
+
+};
+
+#endif // HISTOGRAMWIDGET_H

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -6,6 +6,7 @@
 #include <QHBoxLayout>
 #include "crosssectionrenderer.h"
 #include "transferfunctionwidget.h"
+#include "histogramwidget.h"
 
 MainWindow::MainWindow(Environment *env, QWidget *parent)
     : QMainWindow(parent), m_environment(env)
@@ -36,7 +37,7 @@ MainWindow::MainWindow(Environment *env, QWidget *parent)
     fileMenu->addAction(fileRemoveWidgetAction);
 
     QAction *fileComputeAction = new QAction("Compute",this);
-    connect(fileComputeAction,SIGNAL(triggered()),m_renderWidgets.first(),SLOT(doCompute()));
+//    connect(fileComputeAction,SIGNAL(triggered()),m_renderWidgets.first(),SLOT(doCompute()));
     fileMenu->addAction(fileComputeAction);
 
     menuBar()->addMenu(fileMenu);
@@ -50,6 +51,9 @@ MainWindow::MainWindow(Environment *env, QWidget *parent)
     TransferFunctionWidget *tfWidget = new TransferFunctionWidget(m_environment, m_mainWidget);
     m_layout->addWidget(tfWidget);
     tfWidget->show();
+
+    connect(fileComputeAction,SIGNAL(triggered()),this,SLOT(computeActionTriggered()));
+    fileMenu->addAction(fileComputeAction);
 }
 
 MainWindow::~MainWindow()
@@ -65,6 +69,10 @@ void MainWindow::fileOpen()
         m_environment->volume()->load(fileName);
     }
 
+}
+
+void MainWindow::computeActionTriggered(){
+    emit doCompute();
 }
 
 // WORKAROUND

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -7,6 +7,7 @@
 #include "crosssectionrenderer.h"
 #include "transferfunctionwidget.h"
 #include "histogramwidget.h"
+#include "sidebar.h"
 
 MainWindow::MainWindow(Environment *env, QWidget *parent)
     : QMainWindow(parent), m_environment(env)
@@ -19,8 +20,9 @@ MainWindow::MainWindow(Environment *env, QWidget *parent)
     m_layout = new QHBoxLayout(m_mainWidget);
 
     setCentralWidget(m_mainWidget);
-    addWidget();
-
+//    addWidget();
+    RenderWidget *widget = new RenderWidget(m_environment,m_mainWidget);
+    m_layout->addWidget(widget,2);
 
     QMenu *fileMenu = new QMenu("File");
 
@@ -37,20 +39,13 @@ MainWindow::MainWindow(Environment *env, QWidget *parent)
     fileMenu->addAction(fileRemoveWidgetAction);
 
     QAction *fileComputeAction = new QAction("Compute",this);
-//    connect(fileComputeAction,SIGNAL(triggered()),m_renderWidgets.first(),SLOT(doCompute()));
     fileMenu->addAction(fileComputeAction);
 
     menuBar()->addMenu(fileMenu);
 
-//  CROSS SECTION
-    CrossSectionRenderer *widget = new CrossSectionRenderer(m_environment, m_mainWidget);
-    m_layout->addWidget(widget);
-    widget->show();
-
-    // TransferFunction
-    TransferFunctionWidget *tfWidget = new TransferFunctionWidget(m_environment, m_mainWidget);
-    m_layout->addWidget(tfWidget);
-    tfWidget->show();
+    // SIDE BAR
+    SideBar *sideBar = new SideBar(m_environment,m_mainWidget);
+    m_layout->addWidget(sideBar,1);
 
     connect(fileComputeAction,SIGNAL(triggered()),this,SLOT(computeActionTriggered()));
     fileMenu->addAction(fileComputeAction);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -15,11 +15,14 @@ class MainWindow : public QMainWindow
 public:
     MainWindow(Environment *env, QWidget *parent = nullptr);
     ~MainWindow();
+signals:
+    void doCompute();
 
 public slots:
     void fileOpen();
     void addWidget();
     void removeWidget();
+    void computeActionTriggered();
 
 private:
     Environment *m_environment;

--- a/node.h
+++ b/node.h
@@ -14,6 +14,7 @@ public:
     void setPos(QVector2D newPos) {m_pos = newPos;};
     void setColor(QColor newColor) {m_color = newColor; repaint();};
     void moveNode(QVector2D moveVec){setPos(m_pos + moveVec);};
+    void rendererResized(QSize oldSize, QSize newSize);
     QColor getColor() {return m_color;};
 
     QVector4D getInfo();
@@ -24,12 +25,15 @@ protected:
     virtual void mouseMoveEvent(QMouseEvent *event);
     virtual void mousePressEvent(QMouseEvent *event);
     virtual void mouseReleaseEvent(QMouseEvent *event);
+//    virtual void resizeEvent(QResizeEvent *event);
     virtual QSize sizeHint() const;
 signals:
     void nodeSelected(Node* = nullptr);
 public slots:
     void updateValues();
 private:
+    void moveWithinBoundaries(float x, float y) {moveWithinBoundaries(QVector2D(x,y));};
+    void moveWithinBoundaries(QVector2D pos);
     QVector2D m_pos;
     QColor m_color;
     bool m_isSelected = false;

--- a/raymarching-fs.glsl
+++ b/raymarching-fs.glsl
@@ -48,6 +48,8 @@ vec3 gradient(vec3 p) {
 
 void main(void)
 {
+    gl_FragDepth = 0;
+
     vec4 near = MVP * vec4(fragCoord, -1., 1.);
     near /= near.w;
 
@@ -89,5 +91,4 @@ void main(void)
     } else{
         gl_FragDepth = 1;
     }
-
 }

--- a/renderwidget.cpp
+++ b/renderwidget.cpp
@@ -151,26 +151,6 @@ void RenderWidget::initializeGL()
     // initialize geometry
     Geometry::instance();
 
-    //Cube
-    if (!m_cubeProgram.addShaderFromSourceFile(QOpenGLShader::Vertex,":/shaders/cube-vs.glsl"))
-        qDebug() << "Could not load cube vertex shader!";
-
-    if (!m_cubeProgram.addShaderFromSourceFile(QOpenGLShader::Fragment,":/shaders/cube-fs.glsl"))
-        qDebug() << "Could not load cube fragment shader!";
-
-    if (!m_cubeProgram.link())
-        qDebug() << "Could not link cube shader program!";
-
-    //Block
-    if (!m_blockProgram.addShaderFromSourceFile(QOpenGLShader::Vertex,":/shaders/block-vs.glsl"))
-        qDebug() << "Could not load block vertex shader!";
-
-    if (!m_blockProgram.addShaderFromSourceFile(QOpenGLShader::Fragment,":/shaders/block-fs.glsl"))
-        qDebug() << "Could not load block fragment shader!";
-
-    if (!m_blockProgram.link())
-        qDebug() << "Could not link block shader program!";
-
     //Histogram
     if (!m_histogramProgram.addShaderFromSourceFile(QOpenGLShader::Vertex,":/shaders/histogram-vs.glsl"))
         qDebug() << "Could not load histogram vertex shader!";

--- a/renderwidget.h
+++ b/renderwidget.h
@@ -33,8 +33,6 @@ private:
     void pan(QVector3D direction);
 
     Environment * m_environment;
-    QOpenGLShaderProgram m_cubeProgram;
-    QOpenGLShaderProgram m_blockProgram;
     QOpenGLShaderProgram m_histogramProgram;
     QOpenGLShaderProgram m_computeProgram;
     QOpenGLShaderProgram m_raymarchingProgram;

--- a/sidebar.cpp
+++ b/sidebar.cpp
@@ -1,0 +1,18 @@
+#include "sidebar.h"
+#include <QBoxLayout>
+
+SideBar::SideBar(Environment *env, QWidget *parent)
+    : QWidget{parent},
+      m_environment(env)
+{
+    m_layout = new QBoxLayout(QBoxLayout::TopToBottom,this);
+
+    //CROSS SECTION VIEWER
+    m_csRenderer = new CrossSectionRenderer(m_environment,this);
+    m_layout->addWidget(m_csRenderer,1);
+
+    // TRANSFER FUNCTION WIDGET
+    m_tfWidget = new TransferFunctionWidget(m_environment,this);
+    m_layout->addWidget(m_tfWidget,1);
+
+}

--- a/sidebar.h
+++ b/sidebar.h
@@ -1,0 +1,27 @@
+#ifndef SIDEBAR_H
+#define SIDEBAR_H
+
+#include <QWidget>
+#include <qboxlayout.h>
+#include "environment.h"
+#include "transferfunctionwidget.h"
+#include "crosssectionrenderer.h"
+
+
+class SideBar : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit SideBar(Environment *env, QWidget *parent = nullptr);
+
+signals:
+
+private:
+    Environment *m_environment;
+    QBoxLayout *m_layout;
+    TransferFunctionWidget *m_tfWidget;
+    CrossSectionRenderer *m_csRenderer;
+
+};
+
+#endif // SIDEBAR_H

--- a/transferfunctionbuttonbar.cpp
+++ b/transferfunctionbuttonbar.cpp
@@ -1,0 +1,63 @@
+#include "transferfunctionbuttonbar.h"
+#include <QPushButton>
+
+TransferFunctionButtonBar::TransferFunctionButtonBar(Environment *env, QWidget *parent)
+    : QWidget{parent},
+      m_environment(env)
+{
+    m_layout = new QBoxLayout(QBoxLayout::LeftToRight,this);
+    // Color  Dialog Button
+    m_colorDialogButton = new QPushButton("Color",this);
+    m_layout->addWidget(m_colorDialogButton);
+    // Color Dialog
+    m_colorDialog = new QColorDialog(this);
+    m_layout->addWidget(m_colorDialog);
+    // Hex color text label
+    m_colorNameTextLabel = new QLabel("None",this);
+    m_layout->addWidget(m_colorNameTextLabel);
+    // Add node button
+    m_addNodeButton = new QPushButton("+",this);
+    m_layout->addWidget(m_addNodeButton);
+
+    //Clicking the colog dialog button opens the color menu
+    connect(
+        m_colorDialogButton, SIGNAL(clicked()),
+        m_colorDialog, SLOT(open())
+    );
+    //sets the color text label to the color selected after confirming color menu
+    connect(
+        m_colorDialog, SIGNAL(colorSelected(QColor)),
+        this, SLOT(setColorName(QColor))
+    );
+    //Changes the colorDialogButton's color when a color is selected
+    connect(
+        m_colorDialog, SIGNAL(colorSelected(QColor)),
+        this, SLOT(setColorButtonColor(QColor))
+    );
+    //Adds a new node when + button is clicked
+    connect(
+        m_addNodeButton, SIGNAL(clicked()),
+        parent, SLOT(createNewNodeSlot())
+    );
+    connect(
+        parent, SIGNAL(nodeSelectedSignal(Node*)),
+        this, SLOT(nodeSelectedSlot(Node*))
+    );
+
+}
+
+//SLOT
+void TransferFunctionButtonBar::nodeSelectedSlot(Node *node){
+    setColorName(node->getColor());
+    setColorButtonColor(node->getColor());
+}
+
+//SLOT
+void TransferFunctionButtonBar::setColorName(QColor color){
+    m_colorNameTextLabel->setText(color.name());
+}
+
+//SLOT
+void TransferFunctionButtonBar::setColorButtonColor(QColor color){
+    m_colorDialogButton->setPalette(QPalette(color));
+}

--- a/transferfunctionbuttonbar.h
+++ b/transferfunctionbuttonbar.h
@@ -1,0 +1,33 @@
+#ifndef TRANSFERFUNCTIONBUTTONBAR_H
+#define TRANSFERFUNCTIONBUTTONBAR_H
+
+#include <QWidget>
+#include "environment.h"
+#include <QBoxLayout>
+#include <QColorDialog>
+#include <QLabel>
+
+class TransferFunctionButtonBar : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit TransferFunctionButtonBar(Environment *env, QWidget *parent = nullptr);
+
+signals:
+public slots:
+    void setColorName(QColor color);
+    void setColorButtonColor(QColor color);
+    void nodeSelectedSlot(Node* = nullptr);
+
+private:
+    Environment * m_environment;
+    QBoxLayout *m_layout;
+    QColorDialog *m_colorDialog;
+    QLabel *m_colorNameTextLabel;
+    QPushButton *m_colorDialogButton;
+    QPushButton *m_addNodeButton;
+    Node *m_selectedNode;
+
+};
+
+#endif // TRANSFERFUNCTIONBUTTONBAR_H

--- a/transferfunctionrenderer.cpp
+++ b/transferfunctionrenderer.cpp
@@ -4,10 +4,11 @@
 #include <QVector>
 #include <QColor>
 #include <QVector2D>
+#include <QVBoxLayout>
 #include "transferfunctionrenderer.h"
 #include "node.h"
 #include "environment.h"
-#include "node.h"
+#include "histogramwidget.h"
 
 TransferFunctionRenderer::TransferFunctionRenderer(Environment *env, QWidget *parent)
     : QWidget{parent},
@@ -62,6 +63,11 @@ TransferFunctionRenderer::TransferFunctionRenderer(Environment *env, QWidget *pa
         this, SIGNAL(signalNodeSelected(Node*)),
         parent, SLOT(nodeSelected(Node*))
     );
+
+    //HISTOGRAM
+    HistogramWidget *hgWidget = new HistogramWidget(m_environment, this);
+    hgWidget->setFixedSize(this->size());
+    connect(this->parentWidget()->parentWidget()->parentWidget(),SIGNAL(doCompute()),hgWidget,SLOT(doCompute()));
 }
 
 void TransferFunctionRenderer::slotNodeSelected(Node *node){

--- a/transferfunctionrenderer.h
+++ b/transferfunctionrenderer.h
@@ -12,14 +12,16 @@ public:
 
 protected:
     virtual void paintEvent(QPaintEvent *event);
+    virtual void resizeEvent(QResizeEvent *event);
 signals:
-    void signalUpdateNodeValues();
-    void signalNodeSelected(Node *node);
+    void updateNodeValuesSignal();
+    void nodeSelectedSignal(Node *node);
 public slots:
-    void slotUpdateNodeValues();
+    void updateNodeValuesSlot();
     void createNewNode();
-    void slotNodeSelected(Node *node = nullptr);
+    void nodeSelectedSlot(Node *node = nullptr);
 private:
+    void createDefaultNodes();
     Environment * m_environment;
 
 };

--- a/transferfunctiontexturegenerator.cpp
+++ b/transferfunctiontexturegenerator.cpp
@@ -67,10 +67,13 @@ void TransferFunctionTextureGenerator::sortNodesByXCoord(){
 void TransferFunctionTextureGenerator::placeMiddleValues(){
     //MAKE TEMPORARY QVector<QVector<float>>
     QVector<QVector<float>> temp;
+    int currNodeIdx = 0;
     //CREATE X0 VALUE
     QVector<float> x0 = {0,0,0,0,0};
+    if (m_nodes[0]->x() == .0){
+        currNodeIdx++;
+    }
     temp.append(x0);
-    int currNodeIdx = 0;
     const int numMiddleValues = m_size-m_nodes.size();
 
     for (int i=0; i<numMiddleValues; i++){
@@ -83,9 +86,9 @@ void TransferFunctionTextureGenerator::placeMiddleValues(){
         }
         QVector<float> midVal(5);
         midVal[0] = x;
-        //CASE ON CURRNODE = -1
+        //CASE ON CURRNODE = 0
         if (currNodeIdx==0){
-            //INTERPOLATE BETWEEN X0 AND M_NODES.at(0)
+            //INTERPOLATE BETWEEN X0 AND m_nodedata[0]
             midVal = interpolate(x0,m_nodeData[0],x);
         }
         else if (currNodeIdx >= m_nodes.size()){ //IF PAST LAST NODE

--- a/transferfunctionwidget.h
+++ b/transferfunctionwidget.h
@@ -9,6 +9,7 @@
 #include <QBoxLayout>
 #include "transferfunctionrenderer.h"
 #include "environment.h"
+#include "transferfunctionbuttonbar.h"
 
 class TransferFunctionWidget : public QWidget
 {
@@ -21,23 +22,19 @@ protected:
 signals:
     void updateNodeValues();
     void updateTransferFunctionTexture();
-    void signalCreateNewNode();
+    void createNewNodeSignal();
+    void nodeSelectedSignal(Node *node);
 
 public slots:
-    void setColorName(QColor color);
-    void setColorButtonColor(QColor color);
     void updateTransferFunction();
-    void createNewNode();
-    void nodeSelected(Node *node);
+    void createNewNodeSlot();
+    void nodeSelectedSlot(Node *node);
 private:
     Environment * m_environment;
-    QBoxLayout *m_layout;
-    QColorDialog *m_colorDialog;
-    QLabel *m_colorNameTextLabel;
-    QPushButton *m_colorDialogButton;
+    TransferFunctionButtonBar * m_buttonBar;
+    QBoxLayout * m_layout;
     TransferFunctionRenderer *m_transferFunctionBox;
     QPushButton *m_submitTransferFunctionChangesButton;
-    QPushButton *m_addNodeButton;
     Node *m_selectedNode;
 };
 


### PR DESCRIPTION
ADDITIONS:
- Created SideBar
- Created TransferFunctionButtonBar
- Created HistogramWidget

ARCHITECTURE CHANGES:
- Removed Histogram From RenderWidget
- Moved Histogram to SideBar
- Moved TransferFunctionWidget to SideBar

FIXES:
- Improved Transferfunction editing
- Fixed bug where nodes can be moved out of sight
- Fixed bug where all Transfer Function Nodes start at [0,0]
- Fixed graphical bug when one node is at x=0